### PR TITLE
 feat(theme): Adiciona colors e typography

### DIFF
--- a/bosons/fontLoader/index.jsx
+++ b/bosons/fontLoader/index.jsx
@@ -1,0 +1,16 @@
+import React from 'react';
+import LazyLoad from 'react-lazyload';
+import Head from 'next/head';
+
+function FontLoader() {
+  return (
+    <LazyLoad>
+      <Head>
+        <link href="https://fonts.googleapis.com/css?family=Saira+Extra+Condensed:500,700" rel="stylesheet" />
+        <link href="https://fonts.googleapis.com/css?family=Open+Sans:400,400i" rel="stylesheet" />
+      </Head>
+    </LazyLoad>
+  );
+}
+
+export default FontLoader;

--- a/bosons/themes/base/colors.js
+++ b/bosons/themes/base/colors.js
@@ -1,0 +1,50 @@
+const main = {
+  primary: '#BD5D38',
+};
+
+const mainKeys = Object.keys(main);
+
+const defaults = {
+  coal: {
+    default: '#868E96',
+    dark: '#343A40',
+  },
+  silver: {
+    default: '#F2F0F7',
+    light: '#F9F7FC',
+    dark: '#E8E6F0',
+  },
+};
+
+const colors = {
+  ...main, ...defaults,
+};
+
+/*
+ * This function need receive a label and return a hex color of Style Guide
+ *
+ * If didn't find a color may return the primary.
+ *
+ * The label can be a composed or simple string
+ * For example:
+ * - coal dark
+ * - primary
+ * - silver
+ *
+ * In the case of combined colors need return the "default"
+ * For example:
+ * - silver -> silver deafult
+ * - coal -> coal deafult
+ */
+
+const getColor = (label) => {
+  if (label.length === 0) return main.primary;
+
+  const [name, variant] = label.split(' ');
+
+  if (mainKeys.includes(name)) return colors[name];
+
+  return colors[name][variant || 'default'] || colors.primary;
+};
+
+export default getColor;

--- a/bosons/themes/base/fonts.js
+++ b/bosons/themes/base/fonts.js
@@ -1,0 +1,4 @@
+export default {
+  saira: "'Saira Extra Condensed', serif",
+  openSans: "'Open Sans', serif",
+};

--- a/bosons/themes/base/index.js
+++ b/bosons/themes/base/index.js
@@ -1,1 +1,9 @@
-export default {};
+import colors from './colors';
+import fonts from './fonts';
+import typography from './typography';
+
+export default {
+  colors,
+  fonts,
+  typography,
+};

--- a/bosons/themes/base/typography.js
+++ b/bosons/themes/base/typography.js
@@ -1,0 +1,69 @@
+import { css } from 'styled-components';
+import fonts from './fonts';
+
+const common = css`
+  margin: 0;
+  padding: 0;
+`;
+
+const display = css`
+  font-size: 6rem;
+  line-height: 6.5rem;
+  font-weight: 700;
+  text-transform: uppercase;
+
+  ${common}
+
+  font-family: ${fonts.saira};
+`;
+
+const h2 = css`
+  font-size: 3.5rem;
+  line-height: 4rem;
+  font-weight: 700;
+  text-transform: uppercase;
+
+  ${common}
+
+  font-family: ${fonts.saira};
+`;
+
+const h3 = css`
+  font-size: 1.75rem;
+  line-height: 2rem;
+  font-weight: 700;
+  text-transform: uppercase;
+
+  ${common}
+
+  font-family: ${fonts.saira};
+`;
+
+const lead = css`
+  font-size: 1.35rem;
+  line-height: 1.5rem;
+  font-weight: 500;
+  text-transform: uppercase;
+
+  ${common}
+
+  font-family: ${fonts.saira};
+`;
+
+const regular = css`
+  font-size: 1rem;
+  line-height: 1.5rem;
+  font-weight: 400;
+
+  ${common}
+
+  font-family: ${fonts.openSans};
+`;
+
+export default {
+  display,
+  h2,
+  h3,
+  lead,
+  regular,
+};

--- a/bosons/themes/index.js
+++ b/bosons/themes/index.js
@@ -1,1 +1,7 @@
-export { default as base } from './base';
+import base from './base';
+
+export default base;
+
+export {
+  base,
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -7592,6 +7592,11 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.6.3.tgz",
       "integrity": "sha512-u7FDWtthB4rWibG/+mFbVd5FvdI20yde86qKGx4lVUTWmPlSWQ4QxbBIrrs+HnXGbxOUlUzTAP/VDmvCwaP2yA=="
     },
+    "react-lazyload": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/react-lazyload/-/react-lazyload-2.5.0.tgz",
+      "integrity": "sha512-RkEwpJDqEUVkXodxBXAI/UDyGYUBTZCU9kdG0Lwmg8BIv8zDvP+exFwUzc7wP4HX6n33CCsz+cjG2FpwdRoxpw=="
+    },
     "react-test-renderer": {
       "version": "16.8.6",
       "resolved": "https://registry.npmjs.org/react-test-renderer/-/react-test-renderer-16.8.6.tgz",

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "next": "8.0.3",
     "react": "16.8.5",
     "react-dom": "16.8.5",
+    "react-lazyload": "2.5.0",
     "styled-components": "4.2.0",
     "styled-normalize": "8.0.6",
     "styled-reset": "2.0.4"

--- a/pages/_app.jsx
+++ b/pages/_app.jsx
@@ -3,6 +3,7 @@ import App, { Container } from 'next/app';
 import { ThemeProvider } from 'styled-components';
 
 import GlobalCSS from '../bosons/globalCSS';
+import FontLoader from '../bosons/fontLoader';
 import { base } from '../bosons/themes';
 
 class MyApp extends App {
@@ -24,6 +25,7 @@ class MyApp extends App {
       <ThemeProvider theme={base}>
         <Container>
           <GlobalCSS />
+          <FontLoader />
           <Component {...pageProps} />
         </Container>
       </ThemeProvider>


### PR DESCRIPTION
## Descrição

_Adiciona colors e typography ao tema_

## Detalhes

Este PR adiciona ao tema do styled components cores e tipografia. Com o objetivo de padronizar e reutilizar essas informações em qualquer componente.

### Colors

Tirando as cores principais (`main`) que devem seguir padrão `primary` e `secondary` todas as outras cores devem ser adicionadas no `defaults` ou outro escopo (Ex: alerts) e o mesmo deve seguir o seguinte padrão: label (`coal`, `silver` e etc) e cada uma delas com no mínimo uma cor `default`.
Ex:
```jsx
/* Only Default */
const defaults = {
  coal: {
    default: '#3d3d3d',
  },
};

/* More default */
const defaults = {
  coal: {
    default: '#3d3d3d',
    dark: '#1d1d1d',
  },
};
```

### Typography

A tipografia aplicada neste tema segue a seguinte regra: Temos um `Display (h1)`, `h2`, `h3` realcionados aos _headings_ da página. E `lead` e `regular` para os textos padrões da página.

Todos os _headings_ e o _lead_ usam fonte `Saira` e o regular usa `Open Sans`.

## Referências

- [Styled Component Theming](https://www.styled-components.com/docs/advanced#theming)

