### PR TITLE
 feat(theme): Adiciona breakpoints e space ao tema 

### DIFF
--- a/bosons/themes/base/breakpoints.js
+++ b/bosons/themes/base/breakpoints.js
@@ -1,0 +1,36 @@
+const breakpoints = {
+  xs: 0,
+  sm: 576,
+  md: 768,
+  lg: 992,
+  xl: 1200,
+};
+
+const keys = Object.keys(breakpoints);
+const unit = 'px';
+
+function up(key) {
+  return `@media (min-width: ${breakpoints[key]}${unit})`;
+}
+
+function between(start, end) {
+  const endIndex = keys.indexOf(end) + 1;
+
+  if (endIndex === keys.length) {
+    return up(start);
+  }
+
+  return `@media (min-width: ${breakpoints[start]}${unit}) and (max-width: ${breakpoints[keys[endIndex]]}${unit})`;
+}
+
+function get(key) {
+  if (!breakpoints[key]) return null;
+
+  return `${breakpoints[key]}${unit}`;
+}
+
+export default {
+  up,
+  between,
+  get,
+};

--- a/bosons/themes/base/index.js
+++ b/bosons/themes/base/index.js
@@ -1,8 +1,10 @@
+import breakpoints from './breakpoints';
 import colors from './colors';
 import fonts from './fonts';
 import typography from './typography';
 
 export default {
+  breakpoints,
   colors,
   fonts,
   typography,

--- a/bosons/themes/base/index.js
+++ b/bosons/themes/base/index.js
@@ -1,11 +1,13 @@
 import breakpoints from './breakpoints';
 import colors from './colors';
 import fonts from './fonts';
+import space from './space';
 import typography from './typography';
 
 export default {
   breakpoints,
   colors,
   fonts,
+  space,
   typography,
 };

--- a/bosons/themes/base/space.js
+++ b/bosons/themes/base/space.js
@@ -1,0 +1,16 @@
+const baseUnit = 8;
+const unit = 'px';
+
+export const spaces = ({
+  micro: `${baseUnit}${unit}`,
+  small: `${2 * baseUnit}${unit}`,
+  base: `${3 * baseUnit}${unit}`,
+  large: `${4 * baseUnit}${unit}`,
+  mega: `${6 * baseUnit}${unit}`,
+});
+
+function getSpace(name) {
+  return spaces[name] || spaces.base;
+}
+
+export default getSpace;


### PR DESCRIPTION
## Descrição

_Adiciona breakpoints e space ao tema_

## Detalhes

Este PR adiciona _breakpoints_ e espaçamento ao tema do _styled component_. Com o objetivo de padronizar e reutilizar essas informações em qualquer componente.

### Breakpoints

Seguindo rigorosamente a ideia do _mobile-first_ foi disponibilizado apenas funções de `up(key)` e `between(start, end)`
Os _breakpoints_ são:
```js
xs: 0
sm: 576
md: 768
lg: 992
xl: 1200
```

### Space

O espaçamento contém os seguintes valores:
```jsx
micro: 8px
small: 16px
base: 24px
large: 32px
mega: 48px
```

## Referências

- [Styled Component Theming](https://www.styled-components.com/docs/advanced#theming)
