### PR TITLE
feat: Cria componente Avatar

### DIFF
--- a/atoms/Avatar/index.jsx
+++ b/atoms/Avatar/index.jsx
@@ -1,0 +1,33 @@
+import React from 'react';
+import { string, bool } from 'prop-types';
+
+import {
+  AvatarContainer,
+  AvatarContent,
+  AvatarImage,
+} from './styles';
+
+function Avatar(props) {
+  const { src, alt, ...other } = props;
+
+  return (
+    <AvatarContainer {...other}>
+      <AvatarContent {...other}>
+        <AvatarImage src={src} alt={alt} />
+      </AvatarContent>
+    </AvatarContainer>
+  );
+}
+
+Avatar.propTypes = {
+  src: string,
+  alt: string.isRequired,
+  rounded: bool,
+};
+
+Avatar.defaultProps = {
+  src: '',
+  rounded: true,
+};
+
+export default Avatar;

--- a/atoms/Avatar/styles.js
+++ b/atoms/Avatar/styles.js
@@ -1,0 +1,38 @@
+import styled, { css } from 'styled-components';
+
+const roundedStyle = css`
+  border-radius: 50%;
+  overflow: hidden;
+`;
+
+const AvatarContainer = styled.div`
+  padding: ${({ theme: { space } }) => space('small')};
+  background-color: rgba(255, 255, 255, .6);
+
+  ${({ rounded }) => rounded && roundedStyle}
+`;
+
+const AvatarContent = styled.div`
+  width: 100%;
+  padding-top: 50%;
+  padding-bottom: 50%;
+  position: relative;
+
+  ${({ rounded }) => rounded && roundedStyle}
+`;
+
+const AvatarImage = styled.img`
+  position: absolute;
+  top: 0;
+  left: 0;
+  bottom: 0;
+  right: 0;
+
+  height: 100%;
+`;
+
+export {
+  AvatarContainer,
+  AvatarContent,
+  AvatarImage,
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -6543,6 +6543,17 @@
         "webpack-hot-middleware": "2.24.3",
         "webpack-sources": "1.3.0",
         "worker-farm": "1.5.2"
+      },
+      "dependencies": {
+        "prop-types": {
+          "version": "15.6.2",
+          "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.6.2.tgz",
+          "integrity": "sha512-3pboPvLiWD7dkI3qf3KbUe6hKFKa52w+AE0VCqECtf+QHAKgOL37tTaNCnuX1nAAQ4ZhyP+kYVKf8rLmJ/feDQ==",
+          "requires": {
+            "loose-envify": "^1.3.1",
+            "object-assign": "^4.1.1"
+          }
+        }
       }
     },
     "next-server": {
@@ -6596,6 +6607,15 @@
           "version": "2.1.0",
           "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.1.0.tgz",
           "integrity": "sha512-H2RyIJ7+A3rjkwKC2l5GGtU4H1vkxKCAGsWasNVd0Set+6i4znxbWy6/j16YDPJDWxhsgZiKAstMEP8wCdSpjA=="
+        },
+        "prop-types": {
+          "version": "15.6.2",
+          "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.6.2.tgz",
+          "integrity": "sha512-3pboPvLiWD7dkI3qf3KbUe6hKFKa52w+AE0VCqECtf+QHAKgOL37tTaNCnuX1nAAQ4ZhyP+kYVKf8rLmJ/feDQ==",
+          "requires": {
+            "loose-envify": "^1.3.1",
+            "object-assign": "^4.1.1"
+          }
         }
       }
     },
@@ -7415,12 +7435,20 @@
       }
     },
     "prop-types": {
-      "version": "15.6.2",
-      "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.6.2.tgz",
-      "integrity": "sha512-3pboPvLiWD7dkI3qf3KbUe6hKFKa52w+AE0VCqECtf+QHAKgOL37tTaNCnuX1nAAQ4ZhyP+kYVKf8rLmJ/feDQ==",
+      "version": "15.7.2",
+      "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.7.2.tgz",
+      "integrity": "sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==",
       "requires": {
-        "loose-envify": "^1.3.1",
-        "object-assign": "^4.1.1"
+        "loose-envify": "^1.4.0",
+        "object-assign": "^4.1.1",
+        "react-is": "^16.8.1"
+      },
+      "dependencies": {
+        "react-is": {
+          "version": "16.8.6",
+          "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.8.6.tgz",
+          "integrity": "sha512-aUk3bHfZ2bRSVFFbbeVS4i+lNPZr3/WM5jT2J5omUVV1zzcs1nAaf3l51ctA5FFvCRbhrH0bdAsRRQddFJZPtA=="
+        }
       }
     },
     "prop-types-exact": {

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
   "homepage": "https://github.com/mhsalves/my-website#readme",
   "dependencies": {
     "next": "8.0.3",
+    "prop-types": "15.7.2",
     "react": "16.8.5",
     "react-dom": "16.8.5",
     "react-lazyload": "2.5.0",


### PR DESCRIPTION
## Descrição

_Cria componente Avatar_

## Detalhes

Este PR cria um componente átomo de Avatar.
O mesmo tem 3 propriedades: 
- `src` para receber o _path_ da imagem
- `alt` para indicar uma descrição da imagem (_Obrigatório para acessibilidade_)
- `rounded` boleano para habilitar ou não avatar circular.

## Referências

- [Atomic Design](http://bradfrost.com/blog/post/atomic-web-design/)