### PR TITLE
feat: Cria componente Dropdown

### DIFF
--- a/atoms/Dropdown/index.jsx
+++ b/atoms/Dropdown/index.jsx
@@ -1,0 +1,32 @@
+import React from 'react';
+import {
+  node, func, bool,
+} from 'prop-types';
+
+import {
+  DropdownContainer,
+  contentStyle,
+} from './styles';
+
+function Dropdown(props) {
+  const { handler, content, isOpen } = props;
+
+  return (
+    <DropdownContainer>
+      {handler}
+      {content({ contentStyle, isOpen })}
+    </DropdownContainer>
+  );
+}
+
+Dropdown.propTypes = {
+  handler: node.isRequired,
+  content: func.isRequired,
+  isOpen: bool,
+};
+
+Dropdown.defaultProps = {
+  isOpen: false,
+};
+
+export default Dropdown;

--- a/atoms/Dropdown/styles.js
+++ b/atoms/Dropdown/styles.js
@@ -1,0 +1,26 @@
+import styled, { css } from 'styled-components';
+
+const showStyle = css`
+  opacity: ${({ isOpen }) => (isOpen ? '1' : '0')};
+  visibility: ${({ isOpen }) => (isOpen ? 'visible' : 'hidden')};
+`;
+
+const contentStyle = css`
+  position: absolute;
+  top: 100%;
+  right: 0;
+  left: 0;
+
+  transition: opacity .2s ease, visibility .2s ease;
+  ${showStyle}
+`;
+
+const DropdownContainer = styled.div`
+  position: relative;
+  display: inline;
+`;
+
+export {
+  DropdownContainer,
+  contentStyle,
+};


### PR DESCRIPTION
## Descrição

_Cria componente Dropdown_

## Detalhes

Este PR cria um componente átomo de Dropdown.
A forma como este componente foi criado visa dar liberdade para quem for usá-lo de mudar ou não o comportamento do _content_.

O mesmo tem 3 propriedades: 
- `handler` serve para receber o componente que pode abrir ou fechar o _content_.
- `content` é uma função que envia as propriedades de _content_ (`contentProps: { contentStyle, isOpen }`) do Dropdown pra ser usado pelo componente a ser renderizado.
- `isOpen` é um boleano que serve pra mostrar ou não o _content_.

Exemplo:
```jsx
import React, { useState } from 'react';
import styled from 'styled-components';
import Dropdown from '../atoms/Dropdown';

const Content = styled.div`
  padding: 8px;
  ${({ contentStyle }) => contentStyle}
`;


function Example() {
  const [isOpen, setOpen] = useState(false);

  return (
    <div>
      <Dropdown
        handler={<button onClick={() => setOpen(!isOpen)} type="button">Clique aqui</button>}
        content={
          contentProps => (
            <Content {... contentProps}>
              Hello World !
            </Content>
          )
        }
        isOpen={isOpen}
      />
    </div>
  );
}

export default Example;
```

## Referências

- [Atomic Design](http://bradfrost.com/blog/post/atomic-web-design/)
- [Prop Types](https://reactjs.org/docs/typechecking-with-proptypes.html)
- [React Hooks](https://reactjs.org/docs/hooks-intro.html)