### PR TITLE
update(theme): Troca todas as funções por dicionários

### DIFF
--- a/atoms/Avatar/styles.js
+++ b/atoms/Avatar/styles.js
@@ -6,7 +6,7 @@ const roundedStyle = css`
 `;
 
 const AvatarContainer = styled.div`
-  padding: ${({ theme: { space } }) => space('small')};
+  padding: ${({ theme: { space } }) => space.small};
   background-color: rgba(255, 255, 255, .6);
 
   ${({ rounded }) => rounded && roundedStyle}

--- a/bosons/themes/base/breakpoints.js
+++ b/bosons/themes/base/breakpoints.js
@@ -1,36 +1,12 @@
+/*
+ * Based in the rule mobile-first all breakpoints has only min-width.
+ * PS: the xs point is unnecessary because we don't need a "min-width: 0px"
+ */
 const breakpoints = {
-  xs: 0,
-  sm: 576,
-  md: 768,
-  lg: 992,
-  xl: 1200,
+  sm: '@media (min-width: 576px)',
+  md: '@media (min-width: 768px)',
+  lg: '@media (min-width: 992px)',
+  xl: '@media (min-width: 1200px)',
 };
 
-const keys = Object.keys(breakpoints);
-const unit = 'px';
-
-function up(key) {
-  return `@media (min-width: ${breakpoints[key]}${unit})`;
-}
-
-function between(start, end) {
-  const endIndex = keys.indexOf(end) + 1;
-
-  if (endIndex === keys.length) {
-    return up(start);
-  }
-
-  return `@media (min-width: ${breakpoints[start]}${unit}) and (max-width: ${breakpoints[keys[endIndex]]}${unit})`;
-}
-
-function get(key) {
-  if (!breakpoints[key]) return null;
-
-  return `${breakpoints[key]}${unit}`;
-}
-
-export default {
-  up,
-  between,
-  get,
-};
+export default breakpoints;

--- a/bosons/themes/base/colors.js
+++ b/bosons/themes/base/colors.js
@@ -2,8 +2,6 @@ const main = {
   primary: '#BD5D38',
 };
 
-const mainKeys = Object.keys(main);
-
 const defaults = {
   coal: {
     default: '#868E96',
@@ -20,31 +18,4 @@ const colors = {
   ...main, ...defaults,
 };
 
-/*
- * This function need receive a label and return a hex color of Style Guide
- *
- * If didn't find a color may return the primary.
- *
- * The label can be a composed or simple string
- * For example:
- * - coal dark
- * - primary
- * - silver
- *
- * In the case of combined colors need return the "default"
- * For example:
- * - silver -> silver deafult
- * - coal -> coal deafult
- */
-
-const getColor = (label) => {
-  if (label.length === 0) return main.primary;
-
-  const [name, variant] = label.split(' ');
-
-  if (mainKeys.includes(name)) return colors[name];
-
-  return colors[name][variant || 'default'] || colors.primary;
-};
-
-export default getColor;
+export default colors;

--- a/bosons/themes/base/space.js
+++ b/bosons/themes/base/space.js
@@ -1,7 +1,7 @@
 const baseUnit = 8;
 const unit = 'px';
 
-export const spaces = ({
+const spaces = ({
   micro: `${baseUnit}${unit}`,
   small: `${2 * baseUnit}${unit}`,
   base: `${3 * baseUnit}${unit}`,
@@ -9,8 +9,4 @@ export const spaces = ({
   mega: `${6 * baseUnit}${unit}`,
 });
 
-function getSpace(name) {
-  return spaces[name] || spaces.base;
-}
-
-export default getSpace;
+export default spaces;


### PR DESCRIPTION
## Descrição 

_Troca todas as funções por dicionários_

## Detalhes

Este PR tem como finalidade substituir todas as funções aplicadas no tema do _styled components_ por dicionários. O motivo é que essas funções estão influenciando nas métricas de testes pois os mesmos são importados pelos componentes porém nem todos os casos são usados. Como visto na imagem abaixo:

![image](https://user-images.githubusercontent.com/30807170/55700901-295acf00-599f-11e9-9df9-11569298ef7d.png)

Por exemplo: a função `colors` do tema tem alguns tratamentos aplicados como checar se o mesmo é tipo `main`, se está vazia ou não pra no final retornar uma cor e validar se aquela cor existe e se caso não existe retorna a cor primária. Cada `se` desse é considerado uma `branch` de teste e a maioria deles não está sendo executado.

![image](https://user-images.githubusercontent.com/30807170/55700938-4c857e80-599f-11e9-82a1-a7efd427f7c8.png)

Uma segunda solução seria _mockar_ essas funções durante a execução dos testes. O motivo pelo qual não foi feito é por conta do esforço em _mockar_ cada caso porém caso alguém se interesse, leia [este documento](https://jestjs.io/docs/en/mock-functions)

## Referências

- [O que são branches em testes ?](https://stackoverflow.com/a/35035060)
- [Funções mockadas](https://jestjs.io/docs/en/mock-functions)